### PR TITLE
chore: setup improved GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,18 +3,15 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -22,23 +19,26 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: 'lts/*'
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      run: |
+        if [ -f package-lock.json ]; then
+          npm ci
+        else
+          npm install
+        fi
 
     - name: Build
       run: npm run build
-
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: './dist'
+      env:
+        NODE_ENV: production
 
     - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist
+        enable_jekyll: false

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
-  base: '/VibeCard/',
+  base: mode === 'production' ? '/VibeCard/' : '/',
   server: {
     port: 5173,
     open: true
@@ -18,4 +18,4 @@ export default defineConfig({
       }
     }
   }
-})
+}))


### PR DESCRIPTION
## Summary
- Updated GitHub Actions workflow to use peaceiris/actions-gh-pages@v3 for deploying to gh-pages branch
- Added workflow_dispatch trigger for manual deployments
- Enhanced Vite config to dynamically set base path based on mode (development: '/', production: '/VibeCard/')
- Configured proper permissions and Node.js LTS version
- Added fallback logic for npm install vs npm ci

## Test plan
- [ ] Verify workflow triggers on push to main
- [ ] Test manual workflow dispatch
- [ ] Confirm GitHub Pages deployment to gh-pages branch
- [ ] Validate site functionality on GitHub Pages URL

🤖 Generated with [Same](https://same.new)

Co-Authored-By: Same <noreply@same.new>