### PR TITLE
Fix GitHub Actions workflow duplicate key error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy to GitHub Pages
- 
+
 on:
   push:
     branches: [ main ]
@@ -40,5 +40,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist
-        enable_jekyll: false
         enable_jekyll: false


### PR DESCRIPTION
## Summary
- Removes duplicate `enable_jekyll: false` key in `.github/workflows/deploy.yml`
- Fixes "Invalid workflow file" error that was preventing GitHub Actions from running
- Ensures the peaceiris/actions-gh-pages@v3 action has a clean `with` block with exactly the required parameters

## Test plan
- [x] Verify YAML file syntax is valid
- [ ] Confirm GitHub Actions workflow runs successfully
- [ ] Verify site deployment to GitHub Pages works correctly


Co-Authored-By: Same <noreply@same.new>